### PR TITLE
Removing Suspicious Comments

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,17 +12,12 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+      mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
       Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
       work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
   </head>
@@ -32,12 +27,6 @@
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
     -->
   </body>
 </html>


### PR DESCRIPTION
After viewing the informational vulnerability, it became obvious that the only file that can be touched by the software developers was `index.html`. Moreover, `index.html` was a template used by several web pages, hence why there was a large amount of the vulnerability. The suspicious comments were related to key word searches (mainly the words `user` and `from`). This could be considered a false positive, but `index.html` had information about how to build the application that should be avoided.